### PR TITLE
Potential fix for code scanning alert no. 3: Insecure Direct Object Reference

### DIFF
--- a/CheckMate.WebApi/Controllers/TemplatesController.cs
+++ b/CheckMate.WebApi/Controllers/TemplatesController.cs
@@ -2,6 +2,7 @@ using CheckMate.WebApi.Data;
 using CheckMate.WebApi.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authorization;
 
 namespace CheckMate.WebApi.Controllers;
 
@@ -71,6 +72,7 @@ public class TemplatesController(ApplicationDbContext context) : ControllerBase
         return NoContent();
     }
 
+    [Authorize(Roles = "admin")]
     [HttpDelete("{id}")]
     public async Task<IActionResult> DeleteTemplate(Guid id)
     {


### PR DESCRIPTION
Potential fix for [https://github.com/dylan-smith/CheckMate/security/code-scanning/3](https://github.com/dylan-smith/CheckMate/security/code-scanning/3)

In general, the fix is to ensure that only authorized users can delete a template identified by the `id` parameter. This usually means either (1) enforcing that the current user is allowed to access/delete the specific `Template` instance (e.g., they are the owner), or (2) restricting the action to a privileged role (e.g., administrators) if arbitrary-resource management is acceptable for that role.

Because we must not change existing functionality more than necessary and we have no information about ownership fields on `Template`, the safest, minimal change is to protect the `DeleteTemplate` action with an `[Authorize]` attribute specifying an appropriate role (e.g., `"admin"`). This mirrors the “GOOD” ASP.NET Core example in the background section. Concretely, in `CheckMate.WebApi/Controllers/TemplatesController.cs`, add `using Microsoft.AspNetCore.Authorization;` at the top so we can use `[Authorize]`, and annotate the `DeleteTemplate` method with `[Authorize(Roles = "admin")]` directly above `[HttpDelete("{id}")]`. This leaves the logic of finding and deleting the template unchanged, while ensuring only users with the `admin` role can perform deletions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
